### PR TITLE
fix: do not duplicate extra notes when extra is reserved

### DIFF
--- a/src/modules/arxiv-merge.ts
+++ b/src/modules/arxiv-merge.ts
@@ -171,22 +171,26 @@ export class arXivMerge {
     });
     // Use URL from journal by default, but can be configured to use arXiv URL
     if (getPref("merge.arXivURL")) journalJSON.url = preprintJSON.url;
-    // `extra` field need more care
-    const preprintExtra = Zotero.Utilities.Internal.extractExtraFields(
-      (preprintJSON.extra ?? "") as string,
-    );
-    journalJSON.extra = Zotero.Utilities.Internal.combineExtraFields(
-      (journalJSON.extra ?? "") as string,
-      preprintExtra.fields,
-    );
-    let notes = preprintExtra.extra;
-    // We generally want to keep extra information, but remove arXiv info
-    if (!getPref("merge.arXivExtra"))
-      notes = notes
-        .split("\n")
-        .filter((line) => !line.startsWith("arXiv:"))
-        .join("\n");
-    if (notes) journalJSON.extra += "\n" + notes;
+    // `extra` field need more care. If the user reserves the whole `extra`
+    // field, it is already copied verbatim above and merging the preprint
+    // extra into it again would duplicate its free-text lines.
+    if (!reservedKeys.includes("extra")) {
+      const preprintExtra = Zotero.Utilities.Internal.extractExtraFields(
+        (preprintJSON.extra ?? "") as string,
+      );
+      journalJSON.extra = Zotero.Utilities.Internal.combineExtraFields(
+        (journalJSON.extra ?? "") as string,
+        preprintExtra.fields,
+      );
+      let notes = preprintExtra.extra;
+      // We generally want to keep extra information, but remove arXiv info
+      if (!getPref("merge.arXivExtra"))
+        notes = notes
+          .split("\n")
+          .filter((line) => !line.startsWith("arXiv:"))
+          .join("\n");
+      if (notes) journalJSON.extra += "\n" + notes;
+    }
 
     /* Avoid citation key collision after preprint item updates (say year)
      * For example, no collision:
@@ -203,7 +207,7 @@ export class arXivMerge {
      * TODO: What if the user wants to keep the citation key (not fixed in BBT)?
      */
     const tempExtra = Zotero.Utilities.Internal.combineExtraFields(
-      journalJSON.extra as string,
+      (journalJSON.extra ?? "") as string,
       // @ts-expect-error key not listed in type
       new Map([["Citation Key", crypto.randomUUID()]]),
     );

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -55,6 +55,10 @@ export function setPluginPref(key: string, value: boolean | number | string) {
   return Zotero.Prefs.set(`${config.prefsPrefix}.${key}`, value, true);
 }
 
+export function clearPluginPref(key: string) {
+  return Zotero.Prefs.clear(`${config.prefsPrefix}.${key}`, true);
+}
+
 export async function createItemByDOI(
   doi: string,
 ): Promise<Zotero.Item | false> {

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -1,6 +1,11 @@
 import { assert } from "chai";
 import type Addon from "../src/addon";
-import { clearLibrary, getPlugin, setPluginPref } from "./helpers";
+import {
+  clearLibrary,
+  clearPluginPref,
+  getPlugin,
+  setPluginPref,
+} from "./helpers";
 
 describe("merge", function () {
   let plugin: Addon;
@@ -15,6 +20,7 @@ describe("merge", function () {
   afterEach(async function () {
     setPluginPref("merge.arXivURL", false);
     setPluginPref("merge.arXivExtra", false);
+    clearPluginPref("merge.reservedKeys");
     await clearLibrary();
   });
 
@@ -87,5 +93,35 @@ describe("merge", function () {
     const extra = mergedItem.getField("extra");
     assert.include(extra, "arXiv:1234.5678");
     assert.include(extra, "Kept note");
+  });
+
+  it("should not duplicate extra notes when extra is reserved", async function () {
+    setPluginPref(
+      "merge.reservedKeys",
+      "collections,dateAdded,dateModified,key,tags,relations,extra",
+    );
+    const { preprintItem, publishedItem } = await createMergeItems({
+      preprintExtra: "Citations: 53",
+      publishedExtra: "Published note",
+    });
+
+    await plugin.api.merge(preprintItem, publishedItem, true);
+
+    const mergedItem = await Zotero.Items.getAsync(preprintItem.id);
+    const extra = mergedItem.getField("extra");
+    assert.equal(extra, "Citations: 53");
+  });
+
+  it("should merge items without extra when extra is reserved", async function () {
+    setPluginPref(
+      "merge.reservedKeys",
+      "collections,dateAdded,dateModified,key,tags,relations,extra",
+    );
+    const { preprintItem, publishedItem } = await createMergeItems();
+
+    await plugin.api.merge(preprintItem, publishedItem, true);
+
+    const mergedItem = await Zotero.Items.getAsync(preprintItem.id);
+    assert.equal(mergedItem.getField("extra"), "");
   });
 });


### PR DESCRIPTION
## Problem

With `extra` added to `merge.reservedKeys` (e.g. to preserve Better BibTeX
pinned citation keys), every free-text line of Extra is duplicated on
merge: `journalJSON.extra` already holds the preprint's extra verbatim, and
the extra post-processing then re-appends the preprint's free notes through
`combineExtraFields`. Before: `Citations: 53` — after the merge:
`Citations: 53\nCitations: 53`. The default keep-list (without `extra`) is
unaffected.

## Fix

Skip the extra post-processing when `extra` is reserved (reserved = keep
verbatim), and guard `combineExtraFields` against `extra` missing from the
JSON. Adds a regression test and a `clearPluginPref` helper; the pref is
reset in `afterEach`, so existing tests are unaffected.

Independent of the update-pipeline PR: no overlapping files.